### PR TITLE
GeeksForGeeks recursive binary search now works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /codespan-reporting/target
 a.out
+/letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     # Enables the web UI and tells Traefik to listen to docker
     command:
       - "--api.insecure=true"
+      - "--api.debug=true"
 
       # You need to actively say traefik.enable=true
       - "--providers.docker=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,14 @@ services:
     # Enables the web UI and tells Traefik to listen to docker
     command:
       - "--api.insecure=true"
-      - "--providers.docker=true"
+
       # You need to actively say traefik.enable=true
+      - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
+
       - "--certificatesresolvers.mytlschallenge.acme.tlschallenge=true"
       - "--certificatesresolvers.mytlschallenge.acme.email=al5932@nyu.edu"
       - "--certificatesresolvers.mytlschallenge.acme.storage=letsencrypt/acme.json"
@@ -39,7 +42,7 @@ services:
       - "traefik.http.routers.tci-https.tls.certresolver=mytlschallenge"
 
         #HTTP
-      - "traefik.http.routers.tci-http.rule=Host(`tci.a1liu.com`)"
+      - "traefik.http.routers.tci-http.rule=Host(`tci.a1liu.com`, `localhost`)"
       - "traefik.http.routers.tci-http.service=tci-http"
       - "traefik.http.routers.tci-http.entrypoints=web"
       - "traefik.http.services.tci-http.loadbalancer.server.port=3000"

--- a/includes/stdlib.h
+++ b/includes/stdlib.h
@@ -1,2 +1,2 @@
-void *malloc(long value);
+void *malloc(int value);
 void free(void *value);

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -412,6 +412,14 @@ impl<'a> Assembler<'a> {
                 tagged.op = Opcode::CompI32;
                 ops.push(tagged);
             }
+            TCExprKind::GeqI32(l, r) => {
+                ops.append(&mut self.translate_expr(l));
+                ops.append(&mut self.translate_expr(r));
+                tagged.op = Opcode::Swap { top: 4, bottom: 4 };
+                ops.push(tagged);
+                tagged.op = Opcode::CompI32;
+                ops.push(tagged);
+            }
             TCExprKind::EqI32(l, r) => {
                 ops.append(&mut self.translate_expr(l));
                 ops.append(&mut self.translate_expr(r));

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -374,7 +374,7 @@ impl<'a> Assembler<'a> {
                 ops.push(tagged);
             }
 
-            TCExprKind::List(exprs) => {
+            TCExprKind::ParenList(exprs) => {
                 for (idx, expr) in exprs.iter().enumerate() {
                     ops.append(&mut self.translate_expr(expr));
                     if idx + 1 < exprs.len() {

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -564,6 +564,7 @@ impl<'a> Assembler<'a> {
                     ops.push(tagged);
                 }
             }
+            TCExprKind::BraceList(_) => unreachable!(),
         }
 
         return ops;

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -452,7 +452,7 @@ impl<'a> Assembler<'a> {
                 ops.append(&mut self.translate_expr(r));
                 tagged.op = Opcode::Swap { top: 4, bottom: 4 };
                 ops.push(tagged);
-                tagged.op = Opcode::CompLeqI32;
+                tagged.op = Opcode::CompLtI32;
                 ops.push(tagged);
             }
             TCExprKind::LtI32(l, r) => {
@@ -472,7 +472,7 @@ impl<'a> Assembler<'a> {
                 ops.append(&mut self.translate_expr(r));
                 tagged.op = Opcode::Swap { top: 4, bottom: 4 };
                 ops.push(tagged);
-                tagged.op = Opcode::CompLtI32;
+                tagged.op = Opcode::CompLeqI32;
                 ops.push(tagged);
             }
             TCExprKind::EqI32(l, r) => {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -71,31 +71,32 @@ pub struct Expr<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct DeclReceiver {
+pub struct DeclReceiver<'a> {
     pub pointer_count: u32,
     pub ident: u32,
+    pub array_brackets: &'a [Expr<'a>],
     pub loc: CodeLoc,
 }
 
 #[derive(Debug)]
-pub struct InnerStructDecl {
+pub struct InnerStructDecl<'a> {
     pub decl_type: ASTType,
-    pub recv: DeclReceiver,
+    pub recv: DeclReceiver<'a>,
     pub loc: CodeLoc,
 }
 
 #[derive(Debug, Clone)]
-pub enum ParamKind {
+pub enum ParamKind<'a> {
     StructLike {
         decl_type: ASTType,
-        recv: DeclReceiver,
+        recv: DeclReceiver<'a>,
     },
     Vararg,
 }
 
 #[derive(Debug, Clone)]
-pub struct ParamDecl {
-    pub kind: ParamKind,
+pub struct ParamDecl<'a> {
+    pub kind: ParamKind<'a>,
     pub loc: CodeLoc,
 }
 
@@ -103,13 +104,13 @@ pub struct ParamDecl {
 pub struct StructDecl<'a> {
     pub ident: u32,
     pub ident_loc: CodeLoc,
-    pub members: Option<&'a [InnerStructDecl]>,
+    pub members: Option<&'a [InnerStructDecl<'a>]>,
     pub loc: CodeLoc,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct Decl<'a> {
-    pub recv: DeclReceiver,
+    pub recv: DeclReceiver<'a>,
     pub loc: CodeLoc,
     pub expr: Expr<'a>,
 }
@@ -120,14 +121,14 @@ pub enum GlobalStmtKind<'a> {
         return_type: ASTType,
         pointer_count: u32,
         ident: u32,
-        params: &'a [ParamDecl],
+        params: &'a [ParamDecl<'a>],
         body: &'a [Stmt<'a>],
     },
     FuncDecl {
         return_type: ASTType,
         pointer_count: u32,
         ident: u32,
-        params: &'a [ParamDecl],
+        params: &'a [ParamDecl<'a>],
     },
     StructDecl(StructDecl<'a>),
     Decl {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+use crate::filedb::*;
 use crate::util::*;
 use serde::Serialize;
 
@@ -278,15 +279,15 @@ pub struct TCType {
 }
 
 impl TCType {
-    pub fn display(&self, symbols: &[&str]) -> String {
+    pub fn display(&self, files: &FileDb) -> String {
         let mut writer = StringWriter::new();
         #[rustfmt::skip]
         let result = match self.kind {
-            TCTypeKind::I32 => write!(writer, "I32"),
+            TCTypeKind::I32 => write!(writer, "int"),
             TCTypeKind::U64 => write!(writer, "unsigned long"),
             TCTypeKind::Char => write!(writer, "char"),
             TCTypeKind::Void => write!(writer, "void"),
-            TCTypeKind::Struct { ident, .. } => write!(writer, "struct {}", symbols[ident as usize]),
+            TCTypeKind::Struct { ident, .. } => write!(writer, "struct {}", files.symbol_to_str(ident)),
             TCTypeKind::Uninit { .. } => return "void".to_string(),
             TCTypeKind::BraceList => return "brace_list".to_string()
         };

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -394,6 +394,7 @@ pub enum TCExprKind<'a> {
     LtI32(&'a TCExpr<'a>, &'a TCExpr<'a>),
     EqI32(&'a TCExpr<'a>, &'a TCExpr<'a>),
     NeqI32(&'a TCExpr<'a>, &'a TCExpr<'a>),
+    GeqI32(&'a TCExpr<'a>, &'a TCExpr<'a>),
 
     SConv8To32(&'a TCExpr<'a>),
     SConv32To64(&'a TCExpr<'a>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -275,6 +275,28 @@ pub struct TCType {
     pub pointer_count: u32,
 }
 
+impl TCType {
+    pub fn display(&self, symbols: &[&str]) -> String {
+        let mut writer = StringWriter::new();
+        #[rustfmt::skip]
+        let result = match self.kind {
+            TCTypeKind::I32 => write!(writer, "I32"),
+            TCTypeKind::U64 => write!(writer, "unsigned long"),
+            TCTypeKind::Char => write!(writer, "char"),
+            TCTypeKind::Void => write!(writer, "void"),
+            TCTypeKind::Struct { ident, .. } => write!(writer, "struct {}", symbols[ident as usize]),
+            TCTypeKind::Uninit { .. } => write!(writer, "void"),
+        };
+        result.unwrap();
+
+        for i in 0..self.pointer_count {
+            write!(writer, "*").unwrap();
+        }
+
+        return writer.into_string();
+    }
+}
+
 pub const VOID: TCType = TCType {
     kind: TCTypeKind::Void,
     pointer_count: 0,
@@ -384,6 +406,7 @@ pub enum TCExprKind<'a> {
         var_offset: i16,
     },
 
+    BraceList(&'a [TCExpr<'a>]),
     ParenList(&'a [TCExpr<'a>]),
 
     AddI32(&'a TCExpr<'a>, &'a TCExpr<'a>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10,6 +10,8 @@ pub struct ASTProgram<'a> {
 pub enum BinOp {
     Add,
     Sub,
+    Mul,
+    Div,
     Lt,
     Gt,
     Leq,
@@ -30,6 +32,7 @@ pub enum ExprKind<'a> {
     SizeofExpr(&'a Expr<'a>),
     Ident(u32),
     BinOp(BinOp, &'a Expr<'a>, &'a Expr<'a>),
+    Not(&'a Expr<'a>),
     Assign(&'a Expr<'a>, &'a Expr<'a>),
     Call {
         function: &'a Expr<'a>,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,6 +20,12 @@ pub enum BinOp {
     Neq,
 }
 
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Copy)]
+pub enum UnaryOp {
+    Neg,
+    Not,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum ExprKind<'a> {
     IntLiteral(i32),
@@ -32,6 +38,7 @@ pub enum ExprKind<'a> {
     SizeofExpr(&'a Expr<'a>),
     Ident(u32),
     BinOp(BinOp, &'a Expr<'a>, &'a Expr<'a>),
+    UnaryOp(UnaryOp, &'a Expr<'a>),
     Not(&'a Expr<'a>),
     Assign(&'a Expr<'a>, &'a Expr<'a>),
     Call {
@@ -56,11 +63,17 @@ pub enum ExprKind<'a> {
         ptr: &'a Expr<'a>,
         index: &'a Expr<'a>,
     },
-    List(&'a [Expr<'a>]),
+    BraceList(&'a [Expr<'a>]),
+    ParenList(&'a [Expr<'a>]),
     PostIncr(&'a Expr<'a>),
     PostDecr(&'a Expr<'a>),
     Ref(&'a Expr<'a>),
     Deref(&'a Expr<'a>),
+    Ternary {
+        condition: &'a Expr<'a>,
+        if_true: &'a Expr<'a>,
+        if_false: &'a Expr<'a>,
+    },
     Uninit,
 }
 
@@ -371,7 +384,7 @@ pub enum TCExprKind<'a> {
         var_offset: i16,
     },
 
-    List(&'a [TCExpr<'a>]),
+    ParenList(&'a [TCExpr<'a>]),
 
     AddI32(&'a TCExpr<'a>, &'a TCExpr<'a>),
     AddU64(&'a TCExpr<'a>, &'a TCExpr<'a>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -70,11 +70,17 @@ pub struct Expr<'a> {
     pub loc: CodeLoc,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct DeclReceiver {
+    pub pointer_count: u32,
+    pub ident: u32,
+    pub loc: CodeLoc,
+}
+
 #[derive(Debug)]
 pub struct InnerStructDecl {
     pub decl_type: ASTType,
-    pub pointer_count: u32,
-    pub ident: u32,
+    pub recv: DeclReceiver,
     pub loc: CodeLoc,
 }
 
@@ -82,8 +88,7 @@ pub struct InnerStructDecl {
 pub enum ParamKind {
     StructLike {
         decl_type: ASTType,
-        pointer_count: u32,
-        ident: u32,
+        recv: DeclReceiver,
     },
     Vararg,
 }
@@ -102,10 +107,9 @@ pub struct StructDecl<'a> {
     pub loc: CodeLoc,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Decl<'a> {
-    pub pointer_count: u32,
-    pub ident: u32,
+    pub recv: DeclReceiver,
     pub loc: CodeLoc,
     pub expr: Expr<'a>,
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -230,6 +230,7 @@ pub fn sa(size: u32, align: u32) -> SizeAlign {
 }
 
 pub const TC_UNKNOWN_SIZE: u32 = !0;
+pub const TC_UNKNOWN_ALIGN: u32 = !0;
 pub const TC_UNKNOWN_SA: SizeAlign = SizeAlign {
     size: TC_UNKNOWN_SIZE,
     align: 0,
@@ -267,6 +268,7 @@ pub enum TCTypeKind {
     Void,
     Struct { ident: u32, sa: SizeAlign },
     Uninit { size: u32 },
+    BraceList,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -285,7 +287,8 @@ impl TCType {
             TCTypeKind::Char => write!(writer, "char"),
             TCTypeKind::Void => write!(writer, "void"),
             TCTypeKind::Struct { ident, .. } => write!(writer, "struct {}", symbols[ident as usize]),
-            TCTypeKind::Uninit { .. } => write!(writer, "void"),
+            TCTypeKind::Uninit { .. } => return "void".to_string(),
+            TCTypeKind::BraceList => return "brace_list".to_string()
         };
         result.unwrap();
 
@@ -299,6 +302,11 @@ impl TCType {
 
 pub const VOID: TCType = TCType {
     kind: TCTypeKind::Void,
+    pointer_count: 0,
+};
+
+pub const BRACE_LIST: TCType = TCType {
+    kind: TCTypeKind::BraceList,
     pointer_count: 0,
 };
 
@@ -472,6 +480,7 @@ impl TCType {
             TCTypeKind::Void => TCShallowType::Void,
             TCTypeKind::Struct { .. } => TCShallowType::Struct,
             TCTypeKind::Uninit { .. } => panic!("cannot make shallow of uninit"),
+            TCTypeKind::BraceList => panic!("cannot make shallow of brace list"),
         }
     }
 
@@ -491,6 +500,7 @@ impl TCType {
                 sa.size
             }
             TCTypeKind::Uninit { size } => size,
+            TCTypeKind::BraceList => TC_UNKNOWN_ALIGN,
         }
     }
 
@@ -510,6 +520,7 @@ impl TCType {
                 sa.align
             }
             TCTypeKind::Uninit { size } => size,
+            TCTypeKind::BraceList => TC_UNKNOWN_ALIGN,
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -23,6 +23,11 @@ pub enum ExprKind<'a> {
     IntLiteral(i32),
     CharLiteral(u8),
     StringLiteral(&'a str),
+    SizeofType {
+        sizeof_type: ASTType,
+        pointer_count: u32,
+    },
+    SizeofExpr(&'a Expr<'a>),
     Ident(u32),
     BinOp(BinOp, &'a Expr<'a>, &'a Expr<'a>),
     Assign(&'a Expr<'a>, &'a Expr<'a>),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,12 +52,12 @@ impl From<WriteEvent> for CommandResult {
     }
 }
 
-pub enum WSState<'a> {
-    Files(FileDb<'a>),
+pub enum WSState {
+    Files(FileDb),
     Running(Runtime),
 }
 
-impl<'a> Drop for WSState<'a> {
+impl Drop for WSState {
     fn drop(&mut self) {
         match self {
             WSState::Files(db) => {}
@@ -71,13 +71,13 @@ impl<'a> Drop for WSState<'a> {
     }
 }
 
-impl<'a> Default for WSState<'a> {
+impl Default for WSState {
     fn default() -> Self {
         Self::Files(FileDb::new(false))
     }
 }
 
-impl<'a> WSState<'a> {
+impl WSState {
     pub fn run_command(&mut self, command: Command) -> Vec<CommandResult> {
         let mut messages = Vec::new();
         macro_rules! ret {

--- a/src/filedb.rs
+++ b/src/filedb.rs
@@ -80,6 +80,8 @@ impl<'a> File<'a> {
     }
 }
 
+pub const NO_SYMBOL: u32 = !0;
+
 pub struct FileDb {
     buckets: BucketListRef<'static>,
     pub buckets_next: BucketListRef<'static>,
@@ -249,6 +251,10 @@ impl FileDb {
 
     pub fn symbol_to_str(&self, symbol: u32) -> &str {
         let cloc = self.names[symbol as usize];
+        return self.cloc_to_str(cloc);
+    }
+
+    pub fn cloc_to_str(&self, cloc: CodeLoc) -> &str {
         let range: ops::Range<usize> = cloc.into();
         let text = self.files[cloc.file as usize]._source;
         return unsafe { str::from_utf8_unchecked(&text.as_bytes()[range]) };

--- a/src/filedb.rs
+++ b/src/filedb.rs
@@ -247,6 +247,13 @@ impl FileDb {
         Ok(file_id)
     }
 
+    pub fn symbol_to_str(&self, symbol: u32) -> &str {
+        let cloc = self.names[symbol as usize];
+        let range: ops::Range<usize> = cloc.into();
+        let text = self.files[cloc.file as usize]._source;
+        return unsafe { str::from_utf8_unchecked(&text.as_bytes()[range]) };
+    }
+
     pub fn add_from_symbols(&mut self, base_file: u32, symbol: u32) -> Result<u32, io::Error> {
         let cloc = self.names[symbol as usize];
         let range: ops::Range<usize> = cloc.into();

--- a/src/filedb.rs
+++ b/src/filedb.rs
@@ -80,13 +80,13 @@ impl<'a> File<'a> {
     }
 }
 
-pub struct FileDb<'a> {
-    buckets: BucketListRef<'a>,
-    pub buckets_next: BucketListRef<'a>,
+pub struct FileDb {
+    buckets: BucketListRef<'static>,
+    pub buckets_next: BucketListRef<'static>,
     pub _size: usize,
-    pub file_names: HashMap<&'a str, u32>,
-    pub files: Vec<File<'a>>,
-    pub translate: HashMap<&'a str, u32>,
+    pub file_names: HashMap<&'static str, u32>,
+    pub files: Vec<File<'static>>,
+    pub translate: HashMap<&'static str, u32>,
     pub names: Vec<CodeLoc>,
     pub fs_read_access: bool,
 }
@@ -138,7 +138,7 @@ pub static INIT_SYMS: LazyStatic<InitSyms> = lazy_static!(init_syms_lazy_static,
     }
 });
 
-impl<'a> Drop for FileDb<'a> {
+impl Drop for FileDb {
     fn drop(&mut self) {
         while let Some(b) = unsafe { self.buckets.dealloc() } {
             self.buckets = b;
@@ -146,7 +146,7 @@ impl<'a> Drop for FileDb<'a> {
     }
 }
 
-impl<'a> FileDb<'a> {
+impl FileDb {
     /// Create a new files database.
     pub fn new(fs_read_access: bool) -> Self {
         let mut string = String::new();
@@ -188,20 +188,19 @@ impl<'a> FileDb<'a> {
         new_self
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (u32, &'a str)> {
+    pub fn iter(&self) -> impl Iterator<Item = u32> {
         return self.vec().into_iter();
     }
 
-    pub fn vec(&self) -> Vec<(u32, &'a str)> {
+    pub fn vec(&self) -> Vec<u32> {
         let iter = self.files.iter();
-        #[rustfmt::skip]
-            return iter.enumerate().skip(INIT_SYMS.files.len() + 1)
-                .map(|(id, file)| (id as u32, file._source))
-                .collect();
+        return (0..self.files.len() as u32)
+            .skip(INIT_SYMS.files.len() + 1) // +1 here is for the init syms initial file
+            .collect();
     }
 
     /// Add a file to the database, returning the handle that can be used to
-    /// refer to it again.
+    /// refer to it again. Errors if the file already exists in the database.
     pub fn add(&mut self, file_name: &str, source: &str) -> Result<u32, io::Error> {
         let file_name_owned = canonicalize(file_name)?;
         let file_name = file_name_owned.to_str().unwrap();
@@ -222,7 +221,8 @@ impl<'a> FileDb<'a> {
     }
 
     /// Add a file to the database, returning the handle that can be used to
-    /// refer to it again.
+    /// refer to it again. Returns existing file handle if file already exists in
+    /// the database
     pub fn add_from_fs(&mut self, file_name: &str) -> Result<u32, io::Error> {
         let file_name_owned = canonicalize(file_name)?;
         let file_name = file_name_owned.to_str().unwrap();
@@ -248,7 +248,11 @@ impl<'a> FileDb<'a> {
     }
 
     pub fn add_from_symbols(&mut self, base_file: u32, symbol: u32) -> Result<u32, io::Error> {
-        let text = self.symbol_to_str(symbol);
+        let cloc = self.names[symbol as usize];
+        let range: ops::Range<usize> = cloc.into();
+        let text = self.files[cloc.file as usize]._source;
+        let text = unsafe { str::from_utf8_unchecked(&text.as_bytes()[range]) };
+
         if Path::new(text).is_relative() {
             let base_path = parent_if_file(self.files[base_file as usize]._name);
             let real_path = Path::new(base_path).join(text);
@@ -259,17 +263,6 @@ impl<'a> FileDb<'a> {
         return self.add_from_fs(&text);
     }
 
-    pub fn symbol_to_str(&self, symbol: u32) -> &'a str {
-        let cloc = self.names[symbol as usize];
-        return self.cloc_to_str(cloc);
-    }
-
-    pub fn cloc_to_str(&self, cloc: CodeLoc) -> &'a str {
-        let range: ops::Range<usize> = cloc.into();
-        let text = self.files[cloc.file as usize]._source;
-        return unsafe { str::from_utf8_unchecked(&text.as_bytes()[range]) };
-    }
-
     #[inline]
     pub fn translate_add(&mut self, range: ops::Range<usize>, file: u32) -> u32 {
         let cloc = l(range.start as u32, range.end as u32, file); // TODO check for overflow
@@ -278,7 +271,9 @@ impl<'a> FileDb<'a> {
 
     #[inline]
     pub fn translate_add_cloc(&mut self, cloc: CodeLoc) -> u32 {
-        let text = self.cloc_to_str(cloc);
+        let range: ops::Range<usize> = cloc.into();
+        let text = self.files[cloc.file as usize]._source;
+        let text = unsafe { str::from_utf8_unchecked(&text.as_bytes()[range]) };
 
         if let Some(id) = self.translate.get(text) {
             return *id;
@@ -296,7 +291,7 @@ impl<'a> FileDb<'a> {
     }
 }
 
-impl<'a> Files<'a> for FileDb<'a> {
+impl<'a> Files<'a> for FileDb {
     type FileId = u32;
     type Name = &'a str;
     type Source = &'a str;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -87,8 +87,9 @@ pub enum Opcode {
 
     Pop { bytes: u32 },
     PopKeep { keep: u32, drop: u32 },
-    PushUndef { bytes: u32 }, // Push undefined bytes onto the stack
-    PushDup { bytes: u32 },   // Push bytes duplicated from the top of the stack
+    PushUndef { bytes: u32 },       // Push undefined bytes onto the stack
+    PushDup { bytes: u32 },         // Push bytes duplicated from the top of the stack
+    Swap { top: u32, bottom: u32 }, // Swap some number of top bytes with some number of bytes below
     PopIntoTopVar { offset: u32, bytes: u32 },
 
     SExtend8To16,
@@ -329,6 +330,11 @@ impl Runtime {
             }
             Opcode::PushDup { bytes } => {
                 self.memory.dup_top_stack_bytes(bytes)?;
+            }
+            Opcode::Swap { top, bottom } => {
+                self.memory.dup_top_stack_bytes(top + bottom)?;
+                self.memory.pop_bytes(top)?;
+                self.memory.pop_keep_bytes(top + bottom, bottom)?;
             }
             Opcode::PopIntoTopVar { offset, bytes } => {
                 let ptr = VarPointer::new_stack(self.memory.stack_length(), offset);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -65,8 +65,10 @@ pub const META_NO_SYMBOL: u32 = u32::MAX;
 ///   determined by popping the top of the stack first
 /// - PopKeep pops keep-many bytes off the stack, then pops drop-many bytes off the stack and
 ///   repushes the first set of popped bytes back onto  the stack
-/// - Comp compares pops t, the top of the stack, and compares it to n, the next item on the stack.
+/// - CompLt compares pops t, the top of the stack, and compares it to n, the next item on the stack.
 ///   it pushes the byte 1 onto the stack if n < t, and the byte 0 onto the stack if n >= t.
+/// - CompLeq compares pops t, the top of the stack, and compares it to n, the next item on the stack.
+///   it pushes the byte 1 onto the stack if n <= t, and the byte 0 onto the stack if n > t.
 /// - CompEq compares pops t, the top of the stack, and compares it to n, the next item on the stack.
 ///   it pushes the byte 1 onto the stack if n == t, and the byte 0 onto the stack if n != t.
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -79,8 +81,8 @@ pub enum Opcode {
     StackDealloc,                           // Pops a variable off of the stack
     StackAddToTemp, // Pops a variable off the stack, adding it to the temporary storage below
 
-    MakeTempInt32(i32),
-    MakeTempInt64(i64),
+    MakeTempI32(i32),
+    MakeTempI64(i64),
     MakeTempFloat64(f64),
     MakeTempBinaryPtr { var: u32, offset: u32 },
     MakeTempLocalStackPtr { var: i16, offset: u32 },
@@ -118,7 +120,12 @@ pub enum Opcode {
     SubI32,
     SubI64,
 
-    CompI32,
+    MulI32,
+
+    DivI32,
+
+    CompLtI32,
+    CompLeqI32,
     CompEqI32,
     CompNeqI32,
 
@@ -310,8 +317,8 @@ impl Runtime {
                 self.memory.pop_stack_var_onto_stack()?;
             }
 
-            Opcode::MakeTempInt32(value) => self.memory.push_stack(value.to_be()),
-            Opcode::MakeTempInt64(value) => self.memory.push_stack(value.to_be()),
+            Opcode::MakeTempI32(value) => self.memory.push_stack(value.to_be()),
+            Opcode::MakeTempI64(value) => self.memory.push_stack(value.to_be()),
             Opcode::MakeTempFloat64(value) => self.memory.push_stack(value),
             Opcode::MakeTempBinaryPtr { var, offset } => {
                 let ptr = VarPointer::new_binary(var, offset);
@@ -343,52 +350,52 @@ impl Runtime {
 
             Opcode::SExtend8To16 => {
                 let val = self.memory.pop_stack::<i8>()?;
-                self.memory.push_stack(val as i16);
+                self.memory.push_stack((val as i16).to_be());
             }
             Opcode::SExtend8To32 => {
                 let val = self.memory.pop_stack::<i8>()?;
-                self.memory.push_stack(val as i32);
+                self.memory.push_stack((val as i32).to_be());
             }
             Opcode::SExtend8To64 => {
                 let val = self.memory.pop_stack::<i8>()?;
-                self.memory.push_stack(val as i64);
+                self.memory.push_stack((val as i64).to_be());
             }
             Opcode::SExtend16To32 => {
-                let val = self.memory.pop_stack::<i16>()?;
-                self.memory.push_stack(val as i32);
+                let val = i16::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((val as i32).to_be());
             }
             Opcode::SExtend16To64 => {
-                let val = self.memory.pop_stack::<i16>()?;
-                self.memory.push_stack(val as i64);
+                let val = i16::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((val as i64).to_be());
             }
             Opcode::SExtend32To64 => {
-                let val = self.memory.pop_stack::<i32>()?;
-                self.memory.push_stack(val as i64);
+                let val = i32::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((val as i64).to_be());
             }
 
             Opcode::ZExtend8To16 => {
                 let val = self.memory.pop_stack::<u8>()?;
-                self.memory.push_stack(val as u16);
+                self.memory.push_stack((val as u16).to_be());
             }
             Opcode::ZExtend8To32 => {
                 let val = self.memory.pop_stack::<u8>()?;
-                self.memory.push_stack(val as u32);
+                self.memory.push_stack((val as u32).to_be());
             }
             Opcode::ZExtend8To64 => {
                 let val = self.memory.pop_stack::<u8>()?;
-                self.memory.push_stack(val as u64);
+                self.memory.push_stack((val as u64).to_be());
             }
             Opcode::ZExtend16To32 => {
-                let val = self.memory.pop_stack::<u16>()?;
-                self.memory.push_stack(val as u32);
+                let val = u16::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((val as u32).to_be());
             }
             Opcode::ZExtend16To64 => {
-                let val = self.memory.pop_stack::<u16>()?;
-                self.memory.push_stack(val as u64);
+                let val = u16::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((val as u64).to_be());
             }
             Opcode::ZExtend32To64 => {
-                let val = self.memory.pop_stack::<u32>()?;
-                self.memory.push_stack(val as u64);
+                let val = u32::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((val as u64).to_be());
             }
 
             Opcode::GetLocal { var, offset, bytes } => {
@@ -418,14 +425,28 @@ impl Runtime {
                 let word1 = u32::from_be(self.memory.pop_stack()?);
                 self.memory.push_stack(word1.wrapping_add(word2).to_be());
             }
-
             Opcode::SubI32 => {
                 let word2 = i32::from_be(self.memory.pop_stack()?);
                 let word1 = i32::from_be(self.memory.pop_stack()?);
                 self.memory.push_stack(word1.wrapping_sub(word2).to_be());
             }
+            Opcode::MulI32 => {
+                let word2 = i32::from_be(self.memory.pop_stack()?);
+                let word1 = i32::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack(word1.wrapping_mul(word2).to_be());
+            }
+            Opcode::DivI32 => {
+                let word2 = i32::from_be(self.memory.pop_stack()?);
+                let word1 = i32::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack(word1.wrapping_div(word2).to_be());
+            }
 
-            Opcode::CompI32 => {
+            Opcode::CompLeqI32 => {
+                let word2 = i32::from_be(self.memory.pop_stack()?);
+                let word1 = i32::from_be(self.memory.pop_stack()?);
+                self.memory.push_stack((word1 <= word2) as u8);
+            }
+            Opcode::CompLtI32 => {
                 let word2 = i32::from_be(self.memory.pop_stack()?);
                 let word1 = i32::from_be(self.memory.pop_stack()?);
                 self.memory.push_stack((word1 < word2) as u8);
@@ -445,6 +466,7 @@ impl Runtime {
             Opcode::AddU64 => {
                 let word2 = u64::from_be(self.memory.pop_stack()?);
                 let word1 = u64::from_be(self.memory.pop_stack()?);
+
                 self.memory.push_stack(word1.wrapping_add(word2).to_be());
             }
             Opcode::SubI64 => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -39,7 +39,7 @@ pub enum TokenKind<'a> {
     Dot,
     DotDotDot,
     Arrow,
-    Not,
+    Bang,
     Tilde,
     Star,
     Slash,
@@ -606,7 +606,7 @@ impl<'b> Lexer<'b> {
                     self.current += 1;
                     ret_tok!(TokenKind::Neq);
                 } else {
-                    ret_tok!(TokenKind::Not);
+                    ret_tok!(TokenKind::Bang);
                 }
             }
             b'=' => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -111,12 +111,11 @@ pub type TokenDb<'a> = HashMap<u32, &'a [Token<'a>]>;
 const WHITESPACE: [u8; 2] = [b' ', b'\t'];
 const CRLF: [u8; 2] = [b'\r', b'\n'];
 
-pub fn lex_file<'a, 'b>(
+pub fn lex_file<'b>(
     buckets: BucketListRef<'b>,
     token_db: &mut TokenDb<'b>,
-    symbols: &mut FileDb<'a>,
+    symbols: &mut FileDb,
     file: u32,
-    data: &'a str,
 ) -> Result<&'b [Token<'b>], Error> {
     if let Some(toks) = token_db.get(&file) {
         return Ok(toks);
@@ -143,12 +142,12 @@ impl<'b> Lexer<'b> {
         }
     }
 
-    pub fn lex_file<'a>(
+    pub fn lex_file(
         mut self,
         mut buckets: BucketListRef<'b>,
         incomplete: &mut HashSet<u32>,
         token_db: &mut TokenDb<'b>,
-        symbols: &mut FileDb<'a>,
+        symbols: &mut FileDb,
     ) -> Result<&'b [Token<'b>], Error> {
         let bytes = symbols.source(self.file).unwrap().as_bytes();
 
@@ -167,13 +166,13 @@ impl<'b> Lexer<'b> {
         return Ok(buckets.add_array(self.output));
     }
 
-    pub fn lex_macro_or_token<'a>(
+    pub fn lex_macro_or_token(
         &mut self,
         buckets: BucketListRef<'b>,
         incomplete: &mut HashSet<u32>,
         token_db: &mut TokenDb<'b>,
-        symbols: &mut FileDb<'a>,
-        data: &'a [u8],
+        symbols: &mut FileDb,
+        data: &[u8],
     ) -> Result<bool, Error> {
         loop {
             while self.peek_eqs(data, &WHITESPACE) {
@@ -214,13 +213,13 @@ impl<'b> Lexer<'b> {
         return Ok(false);
     }
 
-    pub fn lex_macro<'a>(
+    pub fn lex_macro(
         &mut self,
         buckets: BucketListRef<'b>,
         incomplete: &mut HashSet<u32>,
         token_db: &mut TokenDb<'b>,
-        symbols: &mut FileDb<'a>,
-        data: &'a [u8],
+        symbols: &mut FileDb,
+        data: &[u8],
     ) -> Result<(), Error> {
         if self.peek_eq(data, b'#') {
             self.current += 1;
@@ -421,11 +420,11 @@ impl<'b> Lexer<'b> {
         return Ok(());
     }
 
-    pub fn lex_token<'a>(
+    pub fn lex_token(
         &mut self,
         buckets: BucketListRef<'b>,
-        symbols: &mut FileDb<'a>,
-        data: &'a [u8],
+        symbols: &mut FileDb,
+        data: &[u8],
     ) -> Result<Token<'b>, Error> {
         let begin = self.current;
         self.current += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use rust_embed::RustEmbed;
 use std::borrow::Cow;
 use util::*;
 
-fn compile<'a>(env: &mut FileDb<'a>) -> Result<Program<'static>, Vec<Error>> {
+fn compile(env: &mut FileDb) -> Result<Program<'static>, Vec<Error>> {
     let mut buckets = buckets::BucketList::with_capacity(2 * env.size());
     let mut buckets_begin = buckets;
     let mut tokens = lexer::TokenDb::new();
@@ -42,8 +42,8 @@ fn compile<'a>(env: &mut FileDb<'a>) -> Result<Program<'static>, Vec<Error>> {
 
     let files_list = env.vec();
     let files = files_list.iter();
-    files.for_each(|&(id, source)| {
-        let result = lexer::lex_file(buckets, &mut tokens, env, id, source);
+    files.for_each(|&id| {
+        let result = lexer::lex_file(buckets, &mut tokens, env, id);
         match result {
             Err(err) => {
                 errors.push(err);
@@ -83,7 +83,7 @@ fn compile<'a>(env: &mut FileDb<'a>) -> Result<Program<'static>, Vec<Error>> {
     }
 
     let mut parser = parser::Parser::new();
-    let iter = files_list.into_iter().filter_map(|(file, _)| {
+    let iter = files_list.into_iter().filter_map(|file| {
         while let Some(n) = buckets.next() {
             buckets = n;
         }
@@ -283,13 +283,13 @@ fn respond_to_http_request<'a>(
     });
 }
 
-pub struct WSRuntime<'a> {
-    pub state: commands::WSState<'a>,
+pub struct WSRuntime {
+    pub state: commands::WSState,
     pub results: Vec<commands::CommandResult>,
     pub results_idx: usize,
 }
 
-impl<'a> Default for WSRuntime<'a> {
+impl Default for WSRuntime {
     fn default() -> Self {
         Self {
             state: commands::WSState::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn compile(env: &mut FileDb) -> Result<Program<'static>, Vec<Error>> {
             buckets = n;
         }
 
-        let tfuncs = match type_checker::check_file(buckets, ast) {
+        let tfuncs = match type_checker::check_file(buckets, ast, env) {
             Ok(x) => x,
             Err(err) => {
                 errors.push(err);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::filedb::FileDb;
+use crate::filedb::*;
 use crate::interpreter::{render_err, Runtime};
 use crate::util::*;
 use crate::{compile, emit_err};
@@ -136,5 +136,13 @@ macro_rules! gen_test_runtime_should_fail {
     };
 }
 
-gen_test_should_succeed!(hello_world, assign, structs, includes, control_flow, macros);
+gen_test_should_succeed!(
+    hello_world,
+    assign,
+    structs,
+    includes,
+    control_flow,
+    macros,
+    binary_search
+);
 gen_test_runtime_should_fail!((stack_locals, "InvalidPointer"));

--- a/src/test.rs
+++ b/src/test.rs
@@ -50,6 +50,7 @@ fn test_file_should_succeed(filename: &str) {
     }
 
     let output = writer.into_string();
+    println!("{}", output);
     match read_to_string(String::from(filename) + ".out") {
         Ok(expected) => {
             if output != expected.replace("\r\n", "\n") {

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,16 +21,20 @@ fn test_file_should_succeed(filename: &str) {
         }
     };
     mem::drop(files);
+    // for (idx, op) in program.ops.iter().enumerate() {
+    //     println!("op {}: {:?}", idx, op);
+    // }
 
     let mut runtime = Runtime::new(program, StringArray::new());
 
     let code = match runtime.run(&mut writer) {
         Ok(c) => c,
         Err(err) => {
+            println!("{}", writer.into_string());
+            println!("");
+
+            println!("pc: {}", runtime.memory.pc);
             let print = render_err(&err, &runtime.memory.callstack, &program);
-            for (idx, op) in program.ops.iter().enumerate() {
-                println!("op {}: {:?}", idx, op);
-            }
 
             panic!("{}", print);
         }

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -86,6 +86,19 @@ fn lt_int_int<'b>(buckets: BucketListRef<'b>, l: TCExpr<'b>, r: TCExpr<'b>) -> T
     };
 }
 
+fn geq_int_int<'b>(buckets: BucketListRef<'b>, l: TCExpr<'b>, r: TCExpr<'b>) -> TCExpr<'b> {
+    let result_type = TCType {
+        kind: TCTypeKind::Char,
+        pointer_count: 0,
+    };
+
+    return TCExpr {
+        loc: l_from(l.loc, r.loc),
+        kind: TCExprKind::GeqI32(buckets.add(l), buckets.add(r)),
+        expr_type: result_type,
+    };
+}
+
 fn eq_int_int<'b>(buckets: BucketListRef<'b>, l: TCExpr<'b>, r: TCExpr<'b>) -> TCExpr<'b> {
     let result_type = TCType {
         kind: TCTypeKind::Char,

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -813,7 +813,8 @@ pub fn check_file<'a>(
                 ParamKind::StructLike { decl_type, recv } => (decl_type, *recv),
             };
 
-            if let Some(original) = names.insert(ident, param.loc) {
+            if let Some(original) = names.insert(recv.ident, param.loc) {
+                println!("{}", ident);
                 return Err(error!(
                     "redeclaration of function parameter",
                     original, "original declaration here", param.loc, "second declaration here"
@@ -1387,7 +1388,7 @@ fn check_expr<'b>(
             });
         }
 
-        ExprKind::List(exprs) => {
+        ExprKind::ParenList(exprs) => {
             let mut tc_exprs = Vec::new();
             for expr in exprs {
                 tc_exprs.push(check_expr(buckets, env, local_env, decl_idx, expr)?);
@@ -1395,7 +1396,7 @@ fn check_expr<'b>(
 
             return Ok(TCExpr {
                 expr_type: tc_exprs[tc_exprs.len() - 1].expr_type,
-                kind: TCExprKind::List(buckets.add_array(tc_exprs)),
+                kind: TCExprKind::ParenList(buckets.add_array(tc_exprs)),
                 loc: expr.loc,
             });
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -166,6 +166,12 @@ impl Into<Vec<Error>> for Error {
     }
 }
 
+pub const NO_FILE: CodeLoc = CodeLoc {
+    start: 0,
+    end: 0,
+    file: !0,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 pub struct CodeLoc {
     pub start: u32, // TODO Top 20 bits for start, bottom 12 bits for length?

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::io;
+pub use std::io::Write;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 macro_rules! error {

--- a/test/binary_search.c
+++ b/test/binary_search.c
@@ -5,7 +5,6 @@
 // location of x in given array arr[l..r] is present,
 // otherwise -1
 int binarySearch(int arr[], int l, int r, int x) {
-
   if (r >= l) {
     int mid = l + (r - l) / 2;
 

--- a/test/binary_search.c
+++ b/test/binary_search.c
@@ -5,6 +5,7 @@
 // location of x in given array arr[l..r] is present,
 // otherwise -1
 int binarySearch(int arr[], int l, int r, int x) {
+
   if (r >= l) {
     int mid = l + (r - l) / 2;
 
@@ -33,7 +34,7 @@ int main() {
   int n = sizeof(arr) / sizeof(arr[0]);
   int x = 10;
   int result = binarySearch(arr, 0, n - 1, x);
-  (result == -1) ? printf("Element is not present in array")
-                 : printf("Element is present at index %d", result);
+  (result == -1) ? printf("Element is not present in array\n")
+                 : printf("Element is present at index %d\n", result);
   return 0;
 }

--- a/test/binary_search.c
+++ b/test/binary_search.c
@@ -1,0 +1,39 @@
+// C program to implement recursive Binary Search
+#include <stdio.h>
+
+// A recursive binary search function. It returns
+// location of x in given array arr[l..r] is present,
+// otherwise -1
+int binarySearch(int arr[], int l, int r, int x) {
+  if (r >= l) {
+    int mid = l + (r - l) / 2;
+
+    // If the element is present at the middle
+    // itself
+    if (arr[mid] == x)
+      return mid;
+
+    // If element is smaller than mid, then
+    // it can only be present in left subarray
+    if (arr[mid] > x)
+      return binarySearch(arr, l, mid - 1, x);
+
+    // Else the element can only be present
+    // in right subarray
+    return binarySearch(arr, mid + 1, r, x);
+  }
+
+  // We reach here when element is not
+  // present in array
+  return -1;
+}
+
+int main() {
+  int arr[] = {2, 3, 4, 10, 40};
+  int n = sizeof(arr) / sizeof(arr[0]);
+  int x = 10;
+  int result = binarySearch(arr, 0, n - 1, x);
+  (result == -1) ? printf("Element is not present in array")
+                 : printf("Element is present at index %d", result);
+  return 0;
+}

--- a/test/binary_search.c.out
+++ b/test/binary_search.c.out
@@ -1,0 +1,1 @@
+Element is present at index 3

--- a/test/structs.c
+++ b/test/structs.c
@@ -16,6 +16,8 @@ int main() {
   file2.ident = ident_of(file);
 
   printf("%d\n", file3->ident);
+  printf("sizeof FileId is %d\n", sizeof(struct FileId));
+  printf("sizeof file3.ident is %d\n", sizeof file3.ident);
   file3->ident = 13;
   printf("%d\n", file2);
 }

--- a/test/structs.c.out
+++ b/test/structs.c.out
@@ -1,2 +1,4 @@
 12
+sizeof FileId is 12
+sizeof file3.ident is 4
 13


### PR DESCRIPTION
* sizeof operator
* A bunch of new operators in the opcode interpreter and parser
* Array initialization
* Recursion
* FileDb no longer requires a lifetime argument
* Fixed a bug with Lt/Gt
* Made docker compose work with localhost
* Better type printing on type checking errors
