### PR TITLE
Dawson combine assign

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -672,16 +672,6 @@ impl Assembler {
                 ops.push(tagged);
             }
 
-            TCExprKind::Assign { target, value } => {
-                ops.append(&mut self.translate_expr(value));
-                let bytes = value.expr_type.repr_size();
-                tagged.op = Opcode::PushDup { bytes };
-                ops.push(tagged);
-                ops.append(&mut self.translate_assign(target));
-                tagged.op = Opcode::Set { offset: 0, bytes };
-                ops.push(tagged);
-            }
-
             TCExprKind::MutAssign { target, value, op } => {
                 match op {
                     BinOp::None => {

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -683,114 +683,129 @@ impl Assembler {
             }
 
             TCExprKind::MutAssign { target, value, op } => {
-                ops.append(&mut self.translate_assign(target));
-                tagged.op = Opcode::PushDup { bytes: 8 };
-                ops.push(tagged);
-
-                let bytes = target.target_type.size();
-                tagged.op = Opcode::Get { offset: 0, bytes };
-                ops.push(tagged);
-
-                ops.append(&mut self.translate_expr(value));
-
                 match op {
-                    BinOp::Add => match target.target_type.kind {
-                        TCTypeKind::I32 | TCTypeKind::U32 => {
-                            tagged.op = Opcode::AddU32;
-                        }
-                        TCTypeKind::I64 | TCTypeKind::U64 => {
-                            tagged.op = Opcode::AddU64;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::Sub => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::SubI32;
-                        }
-                        TCTypeKind::I64 => {
-                            tagged.op = Opcode::SubI64;
-                        }
-                        TCTypeKind::U64 => {
-                            tagged.op = Opcode::SubU64;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::Mul => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::MulI32;
-                        }
-                        TCTypeKind::I64 => {
-                            tagged.op = Opcode::MulI64;
-                        }
-                        TCTypeKind::U64 => {
-                            tagged.op = Opcode::MulU64;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::Div => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::DivI32;
-                        }
-                        TCTypeKind::I64 => {
-                            tagged.op = Opcode::DivI64;
-                        }
-                        TCTypeKind::U64 => {
-                            tagged.op = Opcode::DivU64;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::Mod => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::ModI32;
-                        }
-                        TCTypeKind::I64 => {
-                            tagged.op = Opcode::ModI64;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::BitAnd => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::BitAndI32;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::BitXor => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::BitXorI32;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::BitOr => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::BitOrI32;
-                        }
-                        _ => unimplemented!(),
-                    },
-                    BinOp::LShift => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::LShiftI32
-                        }
-                        _ => unimplemented!(),
+                    BinOp::None => {
+                        ops.append(&mut self.translate_expr(value));
+                        let bytes = value.expr_type.repr_size();
+                        tagged.op = Opcode::PushDup { bytes };
+                        ops.push(tagged);
+                        ops.append(&mut self.translate_assign(target));
+                        tagged.op = Opcode::Set { offset: 0, bytes };
+                        ops.push(tagged);
                     }
-                    BinOp::RShift => match target.target_type.kind {
-                        TCTypeKind::I32 => {
-                            tagged.op = Opcode::RShiftI32
+                    _ => {
+                        ops.append(&mut self.translate_assign(target));
+                        tagged.op = Opcode::PushDup { bytes: 8 };
+                        ops.push(tagged);
+
+                        let bytes = target.target_type.size();
+                        tagged.op = Opcode::Get { offset: 0, bytes };
+                        ops.push(tagged);
+
+                        ops.append(&mut self.translate_expr(value));
+                        match op {
+                            BinOp::Add => match target.target_type.kind {
+                                TCTypeKind::I32 | TCTypeKind::U32 => {
+                                    tagged.op = Opcode::AddU32;
+                                }
+                                TCTypeKind::I64 | TCTypeKind::U64 => {
+                                    tagged.op = Opcode::AddU64;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::Sub => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::SubI32;
+                                }
+                                TCTypeKind::I64 => {
+                                    tagged.op = Opcode::SubI64;
+                                }
+                                TCTypeKind::U64 => {
+                                    tagged.op = Opcode::SubU64;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::Mul => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::MulI32;
+                                }
+                                TCTypeKind::I64 => {
+                                    tagged.op = Opcode::MulI64;
+                                }
+                                TCTypeKind::U64 => {
+                                    tagged.op = Opcode::MulU64;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::Div => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::DivI32;
+                                }
+                                TCTypeKind::I64 => {
+                                    tagged.op = Opcode::DivI64;
+                                }
+                                TCTypeKind::U64 => {
+                                    tagged.op = Opcode::DivU64;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::Mod => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::ModI32;
+                                }
+                                TCTypeKind::I64 => {
+                                    tagged.op = Opcode::ModI64;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::BitAnd => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::BitAndI32;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::BitXor => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::BitXorI32;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::BitOr => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::BitOrI32;
+                                }
+                                _ => unimplemented!(),
+                            },
+                            BinOp::LShift => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::LShiftI32
+                                }
+                                _ => unimplemented!(),
+                            }
+                            BinOp::RShift => match target.target_type.kind {
+                                TCTypeKind::I32 => {
+                                    tagged.op = Opcode::RShiftI32
+                                }
+                                _ => unimplemented!(),
+                            }
+                            BinOp::None => {
+        
+                            }
+                            _ => unimplemented!(),
                         }
-                        _ => unimplemented!(),
+                        ops.push(tagged);
+
+                        tagged.op = Opcode::PushDup { bytes };
+                        ops.push(tagged);
+
+                        let top = bytes * 2;
+                        tagged.op = Opcode::Swap { top, bottom: 8 };
+                        ops.push(tagged);
+
+                        tagged.op = Opcode::Set { offset: 0, bytes };
+                        ops.push(tagged);
                     }
-                    _ => unimplemented!(),
                 }
-                ops.push(tagged);
-
-                tagged.op = Opcode::PushDup { bytes };
-                ops.push(tagged);
-
-                let top = bytes * 2;
-                tagged.op = Opcode::Swap { top, bottom: 8 };
-                ops.push(tagged);
-
-                tagged.op = Opcode::Set { offset: 0, bytes };
-                ops.push(tagged);
             }
 
             TCExprKind::Ternary {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -28,6 +28,7 @@ pub enum BinOp {
     BitOr,
     BoolAnd,
     BoolOr,
+    None,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq, Copy)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -52,7 +52,6 @@ pub enum ExprKind<'a> {
     BinOp(BinOp, &'a Expr<'a>, &'a Expr<'a>),
     UnaryOp(UnaryOp, &'a Expr<'a>),
     Not(&'a Expr<'a>),
-    Assign(&'a Expr<'a>, &'a Expr<'a>),
     MutAssign {
         target: &'a Expr<'a>,
         value: &'a Expr<'a>,
@@ -730,11 +729,6 @@ pub enum TCExprKind<'a> {
 
     PostIncrU32(TCAssignTarget<'a>),
     PostIncrU64(TCAssignTarget<'a>),
-
-    Assign {
-        target: TCAssignTarget<'a>,
-        value: &'a TCExpr<'a>,
-    },
 
     MutAssign {
         target: TCAssignTarget<'a>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,7 +116,11 @@ impl<'b> Parser<'b> {
                 let (right, left) = buckets.add((right, left));
                 return Ok(Expr {
                     loc: l_from(left.loc, right.loc),
-                    kind: ExprKind::Assign(left, right),
+                    kind: ExprKind::MutAssign {
+                        target: left,
+                        value: right,
+                        op: BinOp::None,
+                    },
                 });
             }
             TokenKind::PlusEq => {

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -2435,21 +2435,6 @@ pub fn check_expr_allow_brace<'b>(
             }
         }
 
-        ExprKind::Assign(target, value) => {
-            let target = check_assign_target(env, local_env, target)?;
-            let value = check_expr(env, local_env, value)?;
-
-            let value = env.assign_convert(&target.target_type, target.target_loc, value)?;
-
-            let value = env.buckets.add(value);
-
-            return Ok(TCExpr {
-                expr_type: target.target_type,
-                loc: expr.loc,
-                kind: TCExprKind::Assign { target, value },
-            });
-        }
-
         ExprKind::MutAssign { target, value, op } => {
             let target = check_assign_target(env, local_env, target)?;
             let value = check_expr(env, local_env, value)?;


### PR DESCRIPTION
I combined assign and MutAssign in the assembler and removed assign everywhere else. I couldn't figure out a way to implement assign using the MutAssign logic, so I had to use match to include both.