### PR TITLE
Rewrite interpreter to use single address space for all kinds of allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aliu"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4de3e5185c1a1875f4e436f88e1800ed6ecadd8d00251d198380036b6a58b0"
+checksum = "fe14c4116186271bee8948aeb5c633b6dd142fae72982fd3b6c7bf1833d106ed"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aliu"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe14c4116186271bee8948aeb5c633b6dd142fae72982fd3b6c7bf1833d106ed"
+checksum = "392a1309bad924903dbbd0f673cafd4584bb4ad7f24ac72b6ebdfb1ff7a52eba"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,16 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if 1.0.0",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,7 +488,6 @@ name = "tci"
 version = "0.1.0"
 dependencies = [
  "aliu",
- "console_error_panic_hook",
  "hashbrown",
  "interloc",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aliu"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392a1309bad924903dbbd0f673cafd4584bb4ad7f24ac72b6ebdfb1ff7a52eba"
+checksum = "2e45d0b63ae95c3408d7c5666fa416be3ec2717673341635e097479dc2079d1e"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "tci"
 version = "0.1.0"
 authors = ["Albert Liu <albertymliu@gmail.com>"]
 edition = "2018"
+description = "Teaching C Interpreter"
+license = "MIT"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ strum = { version = "0.24.0", features = ["derive"] }
 peg = { version = "0.8.0" }
 hashbrown = { version = "0.9.1", features = ["serde"] }
 unicode-width = "0.1.7"
-aliu = "0.1.18"
+aliu = "0.1.19"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+aliu = "0.1.22"
 wasm-bindgen = { version = "0.2.70", default-features = false }
 js-sys = "0.3.46"
 wasm-bindgen-futures = "0.4.19"
@@ -22,7 +23,6 @@ strum = { version = "0.24.0", features = ["derive"] }
 peg = { version = "0.8.0" }
 hashbrown = { version = "0.9.1", features = ["serde"] }
 unicode-width = "0.1.7"
-aliu = "0.1.20"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc-print = "0.1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,6 @@ hashbrown = { version = "0.9.1", features = ["serde"] }
 unicode-width = "0.1.7"
 aliu = "0.1.19"
 
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.7"
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc-print = "0.1.16"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ strum = { version = "0.24.0", features = ["derive"] }
 peg = { version = "0.8.0" }
 hashbrown = { version = "0.9.1", features = ["serde"] }
 unicode-width = "0.1.7"
-aliu = "0.1.19"
+aliu = "0.1.20"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc-print = "0.1.16"

--- a/lib/header/stdarg.h
+++ b/lib/header/stdarg.h
@@ -1,13 +1,15 @@
 #ifndef __TCI_STDARG_H
 #define __TCI_STDARG_H
 
-typedef struct {
-  void *current;
+typedef struct __builtin_va_list {
+  unsigned int __tci_va_current;
 } va_list;
 
-#define va_start(list, last) ((list).current = &(last), 0)
-#define va_arg(list, type)                                                     \
-  (*(type *)(list.current = ((char *)(list).current) - 1 - (long)(unsigned)-1))
-#define va_end(list) ((list).current = 0)
+#define va_start(list, last) __builtin_va_start(list, last)
+#define va_arg(list, type) (*(type *)(__builtin_va_arg(&list)))
+#define va_end(list) __builtin_va_end(&list)
+
+void *__builtin_va_arg(va_list *list);
+void __builtin_va_end(va_list *list);
 
 #endif

--- a/lib/header/tci.h
+++ b/lib/header/tci.h
@@ -1,6 +1,5 @@
 #ifndef __TCI_TCI_H
 #define __TCI_TCI_H
-#include <stddef.h>
 
 #define TCI_ECALL_EXIT 0U
 #define TCI_ECALL_ARGC 1U
@@ -27,7 +26,7 @@
 #define TCI_ERRNO_TOO_MANY_FILES 5U
 #define TCI_ERRNO_FILES_TOO_LARGE 6U
 
-size_t tci_var_size(void *var);
+unsigned long tci_var_size(void *var);
 
 void tci_throw_error(const char *name, const char *message,
                      unsigned int skip_frames);

--- a/lib/impl/printf.c
+++ b/lib/impl/printf.c
@@ -33,6 +33,7 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/impl/tci.c
+++ b/lib/impl/tci.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <tci.h>
 
-static char *__tci_errno_strs[] = {
+static char *tci_errno_strs[] = {
     /* 0 */ "no error right now!",
     /* 1 */ "file doesn't exist",
     /* 2 */ "file name isn't UTF-8",
@@ -14,6 +14,18 @@ static char *__tci_errno_strs[] = {
     /* 7 */ "reading from a terminal output (standard error)",
     /* 8 */ "reading from a terminal output (standard log)",
     /* 9 */ "writing to a terminal input (standard input)",
+};
+
+static int tci_ecall_param_counts[] = {
+    1, /* TCI_ECALL_EXIT */
+    0, /* TCI_ECALL_ARGC */
+    0, /* TCI_ECALL_ARGV */
+
+    2, /* TCI_ECALL_OPEN_FD */
+    4, /* TCI_ECALL_READ_FD */
+    4, /* TCI_ECALL_WRITE_FD */
+    3, /* TCI_ECALL_APPEND_FD */
+    1  /* TCI_ECALL_FD_LEN */
 };
 
 size_t tci_var_size(void *var) {
@@ -37,21 +49,26 @@ void tci_throw_error(const char *name, const char *message,
 }
 
 void *tci_ecall(int ecall_num, ...) {
+  if (ecall_num >= sizeof(tci_ecall_param_counts) / sizeof(int)) {
+    tci_throw_error(
+        "InvalidEcall",
+        "Called an invalid environment call (this is an error in TCI)", 1);
+  }
+
   va_list list;
   va_start(list, ecall_num);
 
-  const unsigned long diff = ((unsigned long)(unsigned)-1) + 1;
-  void *next = ((char *)list.current) - diff;
-  size_t size = tci_var_size(next);
+  int param_count = tci_ecall_param_counts[ecall_num];
+  void *next;
+  unsigned int size;
 
-  while (size != -1) {
-    __tci_builtin_push((unsigned int)size);
+  for (int i = 0; i < param_count; i++) {
+    next = __builtin_va_arg(&list);
+    size = tci_var_size(next);
+
+    __tci_builtin_push(size);
     __tci_builtin_push(next);
     __tci_builtin_op("PushDyn", sizeof(void));
-
-    list.current = next;
-    next = ((char *)list.current) - diff;
-    size = tci_var_size(next);
   }
 
   va_end(list);
@@ -61,17 +78,29 @@ void *tci_ecall(int ecall_num, ...) {
 }
 
 void tci_perror(char *prefix, int error) {
-  if (error < sizeof(__tci_errno_strs) / sizeof(char *)) {
-    fprintf(stderr, "%s: %s\n", prefix, __tci_errno_strs[error]);
+  if (error < sizeof(tci_errno_strs) / sizeof(char *)) {
+    fprintf(stderr, "%s: %s\n", prefix, tci_errno_strs[error]);
   } else {
     fprintf(stderr, "%s: invalid error code (errno = %d)\n", prefix, error);
   }
 }
 
 char *tci_strerror(int error) {
-  if (error < sizeof(__tci_errno_strs) / sizeof(char *)) {
-    return __tci_errno_strs[error];
+  if (error < sizeof(tci_errno_strs) / sizeof(char *)) {
+    return tci_errno_strs[error];
   }
 
   return NULL;
 }
+
+void *__builtin_va_arg(va_list *list) {
+  __tci_builtin_push(list->__tci_va_current);
+
+  list->__tci_va_current -= 1;
+
+  void *ptr = __tci_builtin_op("TranslateStackId", sizeof(void *));
+
+  return ptr;
+}
+
+void __builtin_va_end(va_list *list) { list->__tci_va_current = -1; }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -91,7 +91,6 @@ lazy_static! {
 
         data.push(Opcode::Call);
         data.push(Opcode::MakeSp);
-        data.push(0i16);
         data.push(Opcode::Get);
         data.push(4u32);
         data.push(Opcode::StackDealloc); // for the return value
@@ -498,7 +497,7 @@ impl Assembler {
                 TCOpcodeKind::Expr(expr) => {
                     self.translate_expr(&expr);
 
-                    let bytes = expr.ty.repr_size();
+                    let bytes: u32 = expr.ty.repr_size();
                     self.func.opcodes.push(Opcode::Pop);
                     self.func.opcodes.push(bytes);
                 }
@@ -1190,7 +1189,6 @@ impl Assembler {
                     self.func.opcodes.push(Opcode::StackAlloc);
                     self.func.opcodes.push(bytes);
                     self.func.opcodes.push(Opcode::MakeSp);
-                    self.func.opcodes.push(0i16);
                     self.func.opcodes.push(Opcode::Set);
                     self.func.opcodes.push(bytes);
                 }
@@ -1206,7 +1204,6 @@ impl Assembler {
                 self.func.opcodes.push(Opcode::Call);
 
                 self.func.opcodes.push(Opcode::MakeSp);
-                self.func.opcodes.push(0i16);
                 self.func.opcodes.push(Opcode::Get);
                 self.func.opcodes.push(rtype_size);
                 self.func.opcodes.push(Opcode::StackDealloc); // for the return value

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -111,7 +111,7 @@ lazy_static! {
 }
 
 pub struct Assembler {
-    pub buckets: aliu::BucketList,
+    pub buckets: BucketList,
 
     pub func_linkage: HashMap<LinkName, u32>,
     pub functions: Vec<ASMFunc>,

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -167,7 +167,7 @@ impl Assembler {
 
         for (loc, static_internal) in &tu.static_internal_vars {
             self.file.binary_offsets[static_internal.var_idx as usize] = self.vars.len() as u32;
-            let vptr = self.data.reserve_static(static_internal.ty.size().into());
+            let (vptr, _block) = self.data.reserve_static(static_internal.ty.size().into());
             let (kind, ty, loc) = (static_internal.init, static_internal.ty, *loc);
             let expr = TCExpr { kind, ty, loc };
             to_init.push((vptr, expr));
@@ -225,7 +225,7 @@ impl Assembler {
                 ));
             }
 
-            let vptr = self.data.reserve_static(global.ty.size().into());
+            let (vptr, _block) = self.data.reserve_static(global.ty.size().into());
             let (kind, ty, loc) = (init, global.ty, global.loc);
             let expr = TCExpr { kind, ty, loc };
             to_init.push((vptr, expr));
@@ -340,7 +340,7 @@ impl Assembler {
             TCExprKind::StringLit(s) => {
                 let bytes = s.as_bytes();
                 let len = bytes.len();
-                let (string, block) = self.data.reserve_static_slice((len + 1) as u32);
+                let (string, block) = self.data.reserve_static((len + 1) as u32);
 
                 block[0..len].copy_from_slice(bytes);
                 block[len] = 0;
@@ -748,7 +748,7 @@ impl Assembler {
 
                 let bytes = val.as_bytes();
                 let len = bytes.len();
-                let (ptr, block) = self.data.reserve_static_slice((len + 1) as u32);
+                let (ptr, block) = self.data.reserve_static((len + 1) as u32);
 
                 block[0..len].copy_from_slice(bytes);
                 block[len] = 0;

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -357,7 +357,7 @@ impl Assembler {
                     let id = self.file.binary_offsets[binary_offset as usize];
 
                     self.var_temps.push((ptr, expr.loc));
-                    self.data.write(ptr, VarPointer::new_binary(id, 0));
+                    self.data.write(ptr, VarPointer::new(id, 0));
                     return Ok(ptr.add(expr.ty.repr_size() as u64));
                 }
 
@@ -375,7 +375,7 @@ impl Assembler {
             }) => {
                 let id = self.file.binary_offsets[binary_offset as usize];
                 self.var_temps.push((ptr, expr.loc));
-                self.data.write(ptr, VarPointer::new_binary(id, offset));
+                self.data.write(ptr, VarPointer::new(id, offset));
             }
 
             TCExprKind::ArrayInit { elems, elem_ty: ty } => {
@@ -511,7 +511,7 @@ impl Assembler {
                     self.solve_scope_difference(defn.ops, scope_idx, label.scope_idx, t_op.loc);
                     self.func.opcodes.push(Opcode::Jump);
                     self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                    self.func.opcodes.push(VarPointer::new_binary(0, goto));
+                    self.func.opcodes.push(VarPointer::new(0, goto));
                 }
                 TCOpcodeKind::GotoIfZero {
                     cond,
@@ -531,7 +531,7 @@ impl Assembler {
 
                     self.func.opcodes.push(op);
                     self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                    self.func.opcodes.push(VarPointer::new_binary(0, goto));
+                    self.func.opcodes.push(VarPointer::new(0, goto));
                 }
                 TCOpcodeKind::GotoIfNotZero {
                     cond,
@@ -551,7 +551,7 @@ impl Assembler {
 
                     self.func.opcodes.push(op);
                     self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                    self.func.opcodes.push(VarPointer::new_binary(0, goto));
+                    self.func.opcodes.push(VarPointer::new(0, goto));
                 }
 
                 TCOpcodeKind::Switch {
@@ -580,7 +580,7 @@ impl Assembler {
                         self.func.opcodes.push(op);
                         self.func.opcodes.push(Opcode::JumpIfZero8);
                         self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                        let ptr = VarPointer::new_binary(0, skip_case);
+                        let ptr = VarPointer::new(0, skip_case);
                         self.func.opcodes.push(ptr);
 
                         self.func.opcodes.push(Opcode::Pop);
@@ -588,7 +588,7 @@ impl Assembler {
 
                         self.func.opcodes.push(Opcode::Jump);
                         self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                        let ptr = VarPointer::new_binary(0, *take_case);
+                        let ptr = VarPointer::new(0, *take_case);
                         self.func.opcodes.push(ptr);
 
                         self.func.labels[skip_case as usize].offset =
@@ -600,7 +600,7 @@ impl Assembler {
 
                     self.func.opcodes.push(Opcode::Jump);
                     self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                    let ptr = VarPointer::new_binary(0, default);
+                    let ptr = VarPointer::new(0, default);
                     self.func.opcodes.push(ptr);
                 }
             }
@@ -777,9 +777,9 @@ impl Assembler {
                 let id = self.func_linkage[&link_name];
                 self.func.opcodes.push(Opcode::Make64);
 
-                let ptr = VarPointer::new_binary(0, self.func.opcodes.data.len() as u32);
+                let ptr = VarPointer::new(0, self.func.opcodes.data.len() as u32);
                 self.function_temps.push((ptr, expr.loc));
-                self.func.opcodes.push(VarPointer::new_binary(0, id));
+                self.func.opcodes.push(VarPointer::new(0, id));
             }
             TCExprKind::GlobalIdent { binary_offset } => {
                 self.func.opcodes.push(Opcode::Loc);
@@ -787,9 +787,9 @@ impl Assembler {
 
                 let id = self.file.binary_offsets[*binary_offset as usize];
                 self.func.opcodes.push(Opcode::Make64);
-                let ptr = VarPointer::new_binary(0, self.func.opcodes.data.len() as u32);
+                let ptr = VarPointer::new(0, self.func.opcodes.data.len() as u32);
                 self.var_temps.push((ptr, expr.loc));
-                self.func.opcodes.push(VarPointer::new_binary(id, 0));
+                self.func.opcodes.push(VarPointer::new(id, 0));
 
                 if !expr.ty.is_array() {
                     self.func.opcodes.push(Opcode::Get);
@@ -1239,13 +1239,13 @@ impl Assembler {
 
                 self.func.opcodes.push(op);
                 self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                let ptr = VarPointer::new_binary(0, else_label);
+                let ptr = VarPointer::new(0, else_label);
                 self.func.opcodes.push(ptr);
 
                 self.translate_expr(if_true);
                 self.func.opcodes.push(Opcode::Jump);
                 self.func.gotos.push(self.func.opcodes.data.len() as u32);
-                self.func.opcodes.push(VarPointer::new_binary(0, end_label));
+                self.func.opcodes.push(VarPointer::new(0, end_label));
                 self.func.labels[else_label as usize].offset = self.func.opcodes.data.len() as u32;
                 self.translate_expr(if_false);
                 self.func.labels[end_label as usize].offset = self.func.opcodes.data.len() as u32;
@@ -1294,9 +1294,9 @@ impl Assembler {
 
                 let id = self.file.binary_offsets[binary_offset as usize];
                 self.func.opcodes.push(Opcode::Make64);
-                let ptr = VarPointer::new_binary(0, self.func.opcodes.data.len() as u32);
+                let ptr = VarPointer::new(0, self.func.opcodes.data.len() as u32);
                 self.var_temps.push((ptr, assign.loc));
-                self.func.opcodes.push(VarPointer::new_binary(id, 0));
+                self.func.opcodes.push(VarPointer::new(id, 0));
 
                 if assign.offset != 0 {
                     self.func.opcodes.push(Opcode::Make64);

--- a/src/filedb.rs
+++ b/src/filedb.rs
@@ -365,6 +365,9 @@ pub enum BuiltinSymbol {
 
     BuiltinPush,
     BuiltinOp,
+
+    VaCurrent,
+    BuiltinVaStart,
 }
 
 impl Symbols {
@@ -381,6 +384,9 @@ impl Symbols {
 
         new_self.add_str("__tci_builtin_push");
         new_self.add_str("__tci_builtin_op");
+
+        new_self.add_str("__tci_va_current");
+        new_self.add_str("__builtin_va_start");
 
         new_self
     }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -17,7 +17,7 @@ pub fn render_err(error: &IError, stack_trace: &Vec<CallFrame>, files: &FileDb) 
     return out;
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub struct IError {
     pub short_name: String,
     pub message: String,

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -69,8 +69,6 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
         Opcode::PushUndef => {
             let bytes: u32 = memory.read_pc()?;
             memory.push_undef(bytes);
-            // let stack_len = memory.expr_stack.len();
-            // memory.expr_stack.resize(stack_len + bytes as usize, 0);
         }
         Opcode::Pop => {
             let bytes: u32 = memory.read_pc()?;

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -61,7 +61,7 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
         }
         Opcode::MakeFp => {
             let var_offset: i16 = memory.read_pc()?;
-            let var = (memory.fp as i16 + var_offset) as u16;
+            let var = (memory.frame.fp as i16 + var_offset) as u16;
 
             memory.push(VarPointer::new_stack(var, 0));
         }

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -55,15 +55,16 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
             memory.push(val);
         }
         Opcode::MakeSp => {
-            let stack_len = memory.stack.len() as u16;
+            let last = *memory.stack.last().unwrap();
 
-            memory.push(VarPointer::new_stack(stack_len, 0));
+            memory.push(VarPointer::new(last, 0));
         }
         Opcode::MakeFp => {
             let var_offset: i16 = memory.read_pc()?;
             let var = (memory.frame.fp as i16 + var_offset) as u16;
+            let value = memory.stack[var];
 
-            memory.push(VarPointer::new_stack(var, 0));
+            memory.push(VarPointer::new(value, 0));
         }
 
         Opcode::PushUndef => {
@@ -992,6 +993,20 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
             } else {
                 memory.push(0 as u64);
             }
+        }
+
+        Opcode::MakeStackId => {
+            let var_offset: i16 = memory.read_pc()?;
+            let var = (memory.frame.fp as i16 + var_offset) as u32;
+
+            memory.push(var);
+        }
+
+        Opcode::TranslateStackId => {
+            let stack_id: u32 = memory.pop()?;
+            let value = memory.stack[stack_id];
+
+            memory.push(VarPointer::new(value, 0));
         }
 
         Opcode::CopySrcToDest => {

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -27,7 +27,7 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
             ));
         }
         Opcode::Loc => {
-            let loc = memory.read_pc()?;
+            let loc: CodeLoc = memory.read_pc()?;
             memory.set_loc(loc);
         }
         Opcode::StackAlloc => {

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -68,8 +68,9 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
 
         Opcode::PushUndef => {
             let bytes: u32 = memory.read_pc()?;
-            let stack_len = memory.expr_stack.len();
-            memory.expr_stack.resize(stack_len + bytes as usize, 0);
+            memory.push_undef(bytes);
+            // let stack_len = memory.expr_stack.len();
+            // memory.expr_stack.resize(stack_len + bytes as usize, 0);
         }
         Opcode::Pop => {
             let bytes: u32 = memory.read_pc()?;

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -55,11 +55,9 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
             memory.push(val);
         }
         Opcode::MakeSp => {
-            let var_offset: i16 = memory.read_pc()?;
             let stack_len = memory.stack.len() as u16;
-            let var = (stack_len as i16 + var_offset) as u16;
 
-            memory.push(VarPointer::new_stack(var, 0));
+            memory.push(VarPointer::new_stack(stack_len, 0));
         }
         Opcode::MakeFp => {
             let var_offset: i16 = memory.read_pc()?;
@@ -74,16 +72,16 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
             memory.expr_stack.resize(stack_len + bytes as usize, 0);
         }
         Opcode::Pop => {
-            let bytes = memory.read_pc()?;
+            let bytes: u32 = memory.read_pc()?;
             memory.pop_bytes(bytes)?;
         }
         Opcode::Swap => {
-            let top_bytes = memory.read_pc()?;
-            let bottom_bytes = memory.read_pc()?;
+            let top_bytes: u32 = memory.read_pc()?;
+            let bottom_bytes: u32 = memory.read_pc()?;
             memory.swap_bytes(top_bytes, bottom_bytes)?;
         }
         Opcode::Dup => {
-            let bytes = memory.read_pc()?;
+            let bytes: u32 = memory.read_pc()?;
             memory.dup_bytes(bytes)?;
         }
         Opcode::PushDyn => {
@@ -282,13 +280,13 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
         }
 
         Opcode::Get => {
-            let bytes = memory.read_pc()?;
+            let bytes: u32 = memory.read_pc()?;
             let ptr: VarPointer = memory.pop()?;
 
             memory.read_bytes_to_stack(ptr, bytes)?;
         }
         Opcode::Set => {
-            let bytes = memory.read_pc()?;
+            let bytes: u32 = memory.read_pc()?;
             let ptr: VarPointer = memory.pop()?;
             memory.write_bytes_from_stack(ptr, bytes)?;
         }
@@ -890,33 +888,33 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
         }
 
         Opcode::Jump => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             memory.jump(target);
         }
 
         Opcode::JumpIfZero8 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u8 = memory.pop()?;
             if value == 0 {
                 memory.jump(target);
             }
         }
         Opcode::JumpIfZero16 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u16 = memory.pop()?;
             if value == 0 {
                 memory.jump(target);
             }
         }
         Opcode::JumpIfZero32 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u32 = memory.pop()?;
             if value == 0 {
                 memory.jump(target);
             }
         }
         Opcode::JumpIfZero64 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u64 = memory.pop()?;
             if value == 0 {
                 memory.jump(target);
@@ -924,28 +922,28 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
         }
 
         Opcode::JumpIfNotZero8 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u8 = memory.pop()?;
             if value != 0 {
                 memory.jump(target);
             }
         }
         Opcode::JumpIfNotZero16 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u16 = memory.pop()?;
             if value != 0 {
                 memory.jump(target);
             }
         }
         Opcode::JumpIfNotZero32 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u32 = memory.pop()?;
             if value != 0 {
                 memory.jump(target);
             }
         }
         Opcode::JumpIfNotZero64 => {
-            let target = memory.read_pc()?;
+            let target: VarPointer = memory.read_pc()?;
             let value: u64 = memory.pop()?;
             if value != 0 {
                 memory.jump(target);
@@ -1073,7 +1071,7 @@ pub fn run_op(memory: &mut Memory) -> Result<Option<EcallExt>, IError> {
         },
 
         Opcode::AssertStr => {
-            let string = memory.pop()?;
+            let string: VarPointer = memory.pop()?;
             memory.cstring_bytes(string)?;
         }
     }

--- a/src/runtime/kernel.rs
+++ b/src/runtime/kernel.rs
@@ -67,7 +67,7 @@ impl Kernel {
             Some(p) => p,
         };
 
-        return tag.memory.loc;
+        return tag.memory.frame.loc;
     }
 
     pub fn cur_mem(&self) -> Option<&Memory> {

--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -117,12 +117,6 @@ impl Memory {
         let var_idx = pc.var_idx() - 1;
         let or_else = || invalid_ptr(pc);
 
-        if pc.is_stack() {
-            return Err(ierror!(
-                "PermissionDenied",
-                "tried to execute memory outside of functions"
-            ));
-        }
         let alloc = self.ranges.get(var_idx).ok_or_else(or_else)?;
         let from_bytes = match *alloc {
             AllocTracker::Exe { start, len } => &self.data[r(start, start + len)],
@@ -230,13 +224,6 @@ impl Memory {
 
         let var_idx = ptr.var_idx() - 1;
         let or_else = || invalid_ptr(ptr);
-
-        if ptr.is_stack() {
-            return Err(ierror!(
-                "InvalidFreeTarget",
-                "tried to free a pointer from the stack"
-            ));
-        }
 
         let free_loc = self.frame_loc(skip_frames)?;
 

--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -22,14 +22,14 @@ impl AllocInfo {
 
 #[derive(Debug)]
 pub struct Memory {
-    pub shared_data: Vec<u8>,
-    pub binary: Vec<Var<()>>,
-    pub heap: Vec<Var<AllocInfo>>,
-    pub freed: usize,
+    shared_data: Vec<u8>,
+    binary: Vec<Var<()>>,
+    heap: Vec<Var<AllocInfo>>,
+    freed: usize,
 
     // Per thread
     pub expr_stack: Vec<u8>,
-    pub stack_data: Vec<u8>,
+    stack_data: Vec<u8>,
     pub stack: Vec<Var<()>>,
     pub callstack: Vec<CallFrame>,
     pub current_func: LinkName,

--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -538,11 +538,9 @@ impl Memory {
         if bytes > self.expr_stack.len() {
             return Err(expr_stack_too_short(stack_len, bytes));
         }
-        self.expr_stack.push_repeat(0, bytes);
 
-        let slice = &mut self.expr_stack[(stack_len - bytes)..];
-        let (from, to) = slice.split_at_mut(bytes);
-        to.copy_from_slice(from);
+        let (from, to) = self.expr_stack.extend_uninit(bytes);
+        to.copy_from_slice(&from[(stack_len - bytes)..]);
 
         return Ok(());
     }

--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -111,14 +111,15 @@ impl Memory {
     }
 
     pub fn read_pc_bytes(&mut self, len: usize) -> Result<&[u8], IError> {
-        if self.frame.pc.var_idx() == 0 {
-            return Err(invalid_ptr(self.frame.pc));
+        let pc = self.frame.pc;
+        if pc.var_idx() == 0 {
+            return Err(invalid_ptr(pc));
         }
 
-        let var_idx = self.frame.pc.var_idx() - 1;
-        let or_else = || invalid_ptr(self.frame.pc);
+        let var_idx = pc.var_idx() - 1;
+        let or_else = || invalid_ptr(pc);
 
-        if self.frame.pc.is_stack() {
+        if pc.is_stack() {
             return Err(ierror!(
                 "PermissionDenied",
                 "tried to execute memory outside of functions"
@@ -136,12 +137,12 @@ impl Memory {
             }
         };
 
-        let (from_len, ptr) = (from_bytes.len() as u32, self.frame.pc);
-        let range = (self.frame.pc.offset() as usize)..(ptr.offset() as usize + len);
+        let (from_len, ptr) = (from_bytes.len() as u32, pc);
+        let range = (pc.offset() as usize)..(ptr.offset() as usize + len);
         let or_else = move || invalid_offset(from_len, ptr, len as u32);
         let from_bytes = from_bytes.get(range).ok_or_else(or_else)?;
 
-        self.frame.pc = self.frame.pc.add(len as u64);
+        self.frame.pc = pc.add(len as u64);
 
         return Ok(from_bytes);
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -32,9 +32,10 @@ pub fn print_error(err: &IError, memory: &Memory, files: &FileDb) -> String {
             .unwrap();
     }
 
-    if memory.loc != NO_FILE {
+    let loc = memory.frame.loc;
+    if loc != NO_FILE {
         Diagnostic::new()
-            .with_labels(vec![Label::new(memory.loc.file, memory.loc)])
+            .with_labels(vec![Label::new(loc.file, loc)])
             .render(files, &mut out)
             .unwrap();
     }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -74,19 +74,6 @@ impl BinaryData {
         );
     }
 
-    pub fn add_static_slice(&mut self, data: &[u8]) -> VarPointer {
-        let data_len = self.data.len();
-
-        self.data.extend_from_slice(data);
-
-        self.vars.push(AllocTracker::Static {
-            start: data_len as u32,
-            len: data.len() as u32,
-        });
-
-        return VarPointer::new_binary(self.vars.len() as u32, 0);
-    }
-
     pub fn add_exe_slice(&mut self, data: &[u8]) -> VarPointer {
         let data_len = self.data.len();
 

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -1,6 +1,16 @@
 use crate::util::*;
 use core::{fmt, mem};
 
+#[derive(Clone, Copy, Debug)]
+pub enum AllocInfo {
+    StackLive { loc: CodeLoc, start: u32, len: u32 },
+    StackDead { loc: CodeLoc },
+    HeapLive { loc: CodeLoc, start: u32, len: u32 },
+    HeapDead { loc: CodeLoc, free_loc: CodeLoc },
+    Static { loc: CodeLoc, start: u32, len: u32 },
+    Exe { start: u32, len: u32 },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Var<T> {
     pub idx: usize,

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -614,7 +614,7 @@ fn id_test() {
 
         // println!("{} -> {}", id, value);
 
-        println!("{}", value);
+        // println!("{:>10}", value);
 
         assert_eq!(id, out_id);
     }
@@ -638,4 +638,5 @@ fn id_test() {
     }
 
     assert_eq!(to_id(0), u32::MAX);
+
 }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -185,7 +185,7 @@ impl BinaryData {
     }
 }
 
-#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy)]
 pub struct VarPointer(u64);
 
 impl fmt::Display for VarPointer {
@@ -256,7 +256,7 @@ impl VarPointer {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct LinkName {
     pub name: u32,
     pub file: n32,

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -638,5 +638,4 @@ fn id_test() {
     }
 
     assert_eq!(to_id(0), u32::MAX);
-
 }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -523,6 +523,11 @@ pub enum Opcode {
     HeapAlloc,
     HeapDealloc,
 
+    // For use with varargs, so we can get the next variable argument from a
+    // decrementing stack id
+    MakeStackId,
+    TranslateStackId,
+
     CopySrcToDest,
     Memset,
 

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -55,23 +55,7 @@ impl BinaryData {
         }
     }
 
-    pub fn reserve_static(&mut self, len: u32) -> VarPointer {
-        let data_len = self.data.len();
-
-        self.data.reserve(len as usize);
-        for _ in 0..len {
-            self.data.push(0);
-        }
-
-        self.vars.push(AllocTracker::Static {
-            start: data_len as u32,
-            len,
-        });
-
-        return VarPointer::new_binary(self.vars.len() as u32, 0);
-    }
-
-    pub fn reserve_static_slice(&mut self, len: u32) -> (VarPointer, &mut [u8]) {
+    pub fn reserve_static(&mut self, len: u32) -> (VarPointer, &mut [u8]) {
         let data_len = self.data.len() as u32;
 
         self.data.reserve(len as usize);

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -637,5 +637,6 @@ fn id_test() {
         assert_eq!(value, out_value);
     }
 
+    // the null address needs to not be a sequential ID that we'll use often
     assert_eq!(to_id(0), u32::MAX);
 }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -200,37 +200,17 @@ impl fmt::Debug for VarPointer {
     }
 }
 impl VarPointer {
-    pub const BINARY_BIT: u64 = 1u64 << 62;
-    pub const STACK_BIT: u64 = 1u64 << 63;
-    pub const RESERVED_BITS: u64 = Self::BINARY_BIT | Self::STACK_BIT;
-
     pub const TOP_BITS: u64 = (u32::MAX as u64) << 32;
     pub const BOTTOM_BITS: u64 = u32::MAX as u64;
 
-    pub fn new_stack(idx: u16, offset: u32) -> VarPointer {
-        let (idx, offset) = (idx as u64, offset as u64);
-        return Self(Self::STACK_BIT | (idx << 32) | offset);
-    }
-
     pub fn new(idx: u32, offset: u32) -> VarPointer {
         let (idx, offset) = ((idx as u64) << 32, offset as u64);
-        if idx & Self::RESERVED_BITS != 0 {
-            panic!("idx is too large");
-        }
 
         return Self(idx | offset);
     }
 
-    pub fn is_stack(self) -> bool {
-        return (self.0 & Self::RESERVED_BITS) == Self::STACK_BIT;
-    }
-
     pub fn var_idx(self) -> usize {
-        let top = if self.is_stack() {
-            self.0 & !Self::RESERVED_BITS
-        } else {
-            self.0 & !Self::RESERVED_BITS
-        };
+        let top = self.0;
 
         return (top >> 32) as usize;
     }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -12,18 +12,41 @@ pub enum AllocTracker {
 }
 
 impl AllocTracker {
+    pub fn is_live(&self) -> bool {
+        match *self {
+            Self::StackLive { loc, start, len } => true,
+            Self::StackDead { loc } => false,
+
+            Self::HeapLive { loc, start, len } => true,
+            Self::HeapDead { loc, free_loc } => false,
+
+            Self::Static { start, len } => true,
+            Self::Exe { start, len } => false,
+        }
+    }
+
     pub fn range(&self) -> (u32, u32) {
         match *self {
+            Self::StackLive { loc, start, len } => {
+                return (start, start + len);
+            }
+            Self::StackDead { loc } => {
+                return (0, 0);
+            }
+
+            Self::HeapLive { loc, start, len } => {
+                return (start, start + len);
+            }
+            Self::HeapDead { loc, free_loc } => {
+                return (0, 0);
+            }
+
             Self::Static { start, len } => {
                 return (start, start + len);
             }
 
             Self::Exe { start, len } => {
                 return (start, start + len);
-            }
-
-            _ => {
-                unimplemented!()
             }
         }
     }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -574,3 +574,68 @@ pub enum FdKind {
     ProcessStdout(u32),
     ProcessStderr(u32),
 }
+
+const ID_MASK: u32 = 0b10100110_01101010_01001010_10101010;
+const ID_ADD: u32 = 2740160927;
+
+// These two numbers are multiplicative inverses mod 2^32
+const ID_MUL_TO: u32 = 0x01000193;
+const ID_MUL_FROM: u32 = 0x359c449b;
+
+// const ID_ROTATE_BITS: u32 = 16;
+// let s2 = s1.swap_bytes();
+// let s5 = s4.rotate_left(ID_ROTATE_BITS);
+
+pub fn to_id(raw: u32) -> u32 {
+    let s1 = raw ^ ID_MASK;
+    let s2 = s1.wrapping_mul(ID_MUL_TO);
+    let s3 = s2.wrapping_sub(ID_ADD);
+
+    return s3;
+}
+
+pub fn from_id(id: u32) -> u32 {
+    let s3 = id.wrapping_add(ID_ADD);
+    let s2 = s3.wrapping_mul(ID_MUL_FROM);
+    let s1 = s2 ^ ID_MASK;
+
+    return s1;
+}
+
+#[test]
+fn id_test() {
+    assert_eq!(ID_MUL_TO.wrapping_mul(ID_MUL_FROM), 1);
+
+    let tests = &[ID_MASK, ID_ADD, ID_MUL_TO, ID_MUL_FROM];
+
+    for id in 0..100 {
+        let value = from_id(id);
+        let out_id = to_id(value);
+
+        // println!("{} -> {}", id, value);
+
+        println!("{}", value);
+
+        assert_eq!(id, out_id);
+    }
+
+    for &id in tests {
+        let value = from_id(id);
+        let out_id = to_id(value);
+
+        // println!("{} -> {}", id, value);
+
+        assert_eq!(id, out_id);
+    }
+
+    for value in 0..100 {
+        let id = to_id(value);
+        let out_value = from_id(id);
+
+        // println!("{} -> {}", id, value);
+
+        assert_eq!(value, out_value);
+    }
+
+    assert_eq!(to_id(0), u32::MAX);
+}

--- a/src/tc_ast.rs
+++ b/src/tc_ast.rs
@@ -2,7 +2,6 @@ use crate::filedb::*;
 use crate::runtime::Opcode;
 use crate::util::*;
 use core::fmt::Write;
-use serde::Serialize;
 
 pub use crate::ast::{BinOp, UnaryOp};
 
@@ -22,7 +21,7 @@ pub enum TCUnaryOp {
     BitNot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct SizeAlign {
     pub size: n32,
     pub align: n32,
@@ -39,7 +38,7 @@ pub const TC_UNKNOWN_SA: SizeAlign = SizeAlign {
     align: n32::NULL,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
 pub enum TCPrimType {
     I8,  // char
     U8,  // unsigned char
@@ -165,8 +164,7 @@ impl TCOpcode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Serialize)]
-#[serde(tag = "kind", content = "data")]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 pub enum TCTypeBase {
     I8,  // char
     U8,  // unsigned char
@@ -243,8 +241,7 @@ impl TCTypeBase {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Serialize)]
-#[serde(tag = "modifier", content = "data")]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 pub enum TCTypeModifier {
     Pointer, // TODO add qualifiers
     Array(u32),
@@ -785,7 +782,7 @@ pub trait TCTy {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub struct TCType {
     pub base: TCTypeBase,
     pub mods: &'static [TCTypeModifier],

--- a/src/tc_ast.rs
+++ b/src/tc_ast.rs
@@ -1141,6 +1141,7 @@ impl<'a> TCTy for TCTypeMut<'a> {
 pub enum TCBuiltin {
     Push(&'static TCExpr), // Any type
     Opcode(Opcode),
+    VaStart { list_label: u32, param_count: u32 },
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/tc_structs.rs
+++ b/src/tc_structs.rs
@@ -13,6 +13,7 @@ pub struct FuncEnv {
     pub translate_gotos: Vec<u32>,
     pub next_label: u32,
     pub next_symbol_label: u32,
+    pub func_ident: u32,
 
     // const fields
     pub return_type: TCType,
@@ -24,6 +25,7 @@ pub enum TypeEnvKind<'a> {
     Local {
         symbols: HashMap<u32, TCVar>,
         scope_idx: u32,
+        func_ident: u32,
         cont_label: n32,
         break_label: n32,
         parent: *mut TypeEnv<'a>,
@@ -53,8 +55,8 @@ pub struct TypeEnv<'a> {
 }
 
 pub struct GlobalTypeEnv<'a> {
-    tu: TranslationUnit,
-    symbols: &'a Symbols,
+    pub tu: TranslationUnit,
+    pub symbols: &'a Symbols,
 }
 
 pub struct LocalTypeEnv<'a> {
@@ -92,11 +94,12 @@ unsafe impl<'a> Allocator for GlobalTypeEnv<'a> {
 }
 
 impl FuncEnv {
-    pub fn new(return_type: TCType, decl_loc: CodeLoc) -> Self {
+    pub fn new(func_ident: u32, return_type: TCType, decl_loc: CodeLoc) -> Self {
         return FuncEnv {
             ops: Vec::new(),
             symbol_to_label: HashMap::new(),
             translate_gotos: Vec::new(),
+            func_ident,
             next_label: 0,
             next_symbol_label: 0,
             return_type,
@@ -208,6 +211,7 @@ impl<'a> TypeEnv<'a> {
         let kind = TypeEnvKind::Local {
             symbols: HashMap::new(),
             scope_idx,
+            func_ident: env.func_ident,
             cont_label: cont_label.into(),
             break_label: break_label.into(),
             parent: self,
@@ -266,6 +270,7 @@ impl<'a> TypeEnv<'a> {
         let kind = TypeEnvKind::Local {
             symbols: HashMap::new(),
             scope_idx: env.ops.len() as u32,
+            func_ident: env.func_ident,
             cont_label,
             break_label,
             parent: self,


### PR DESCRIPTION
With new code,

```c
#include <stdio.h>
#include <stdlib.h>


int* make() {
    int b = 12;
    return &b;
}

int take(int* c) {
    return *c = 12;
}

int main() {

    printf("Hello World %d %d!\n", 12 ,2);

    int* a = malloc(4);

    int* b = make();
    take(b);

    // *b = 12;
    // free(a);
    free(a);

    return 0;
}
```

This program now seg-faults, which is what we want because it involves taking the address of a stack local that then is destroyed at the end of the function `make`.