### PR TITLE
Mark any_as_u8_slice function unsafe

### DIFF
--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -471,7 +471,7 @@ impl Memory {
     }
 
     pub fn push<T: Copy>(&mut self, t: T) {
-        let from_bytes = any_as_u8_slice(&t);
+        let from_bytes = unsafe { any_as_u8_slice(&t) };
         self.expr_stack.extend_from_slice(from_bytes);
     }
 

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -174,7 +174,7 @@ impl BinaryData {
         let (idx, len) = (ptr.offset() as usize, mem::size_of::<T>());
         let to_bytes = data.get_mut(idx..(idx + len)).unwrap();
 
-        let from_bytes = any_as_u8_slice(&t);
+        let from_bytes = unsafe { any_as_u8_slice(&t) };
         to_bytes.copy_from_slice(from_bytes);
     }
 }

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -290,7 +290,7 @@ pub unsafe fn any_as_u8_slice_mut<T: Sized + Copy>(p: &mut T) -> &mut [u8] {
     core::slice::from_raw_parts_mut(p as *mut T as *mut u8, mem::size_of::<T>())
 }
 
-pub fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
+pub unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     unsafe { core::slice::from_raw_parts(p as *const T as *const u8, mem::size_of::<T>()) }
 }
 

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -45,13 +45,13 @@ impl VecU8 {
     }
 
     pub fn push<T: Copy + 'static>(&mut self, t: T) {
-        let from_bytes = any_as_u8_slice(&t);
+        let from_bytes = unsafe { any_as_u8_slice(&t) };
         self.data.extend_from_slice(from_bytes);
     }
 
     pub fn push_aligned<T: Copy + 'static>(&mut self, t: T) {
         self.align(mem::align_of::<T>());
-        let from_bytes = any_as_u8_slice(&t);
+        let from_bytes = unsafe { any_as_u8_slice(&t) };
         self.data.extend_from_slice(from_bytes);
     }
 
@@ -102,13 +102,13 @@ impl<T, E> TaggedMultiArray<T, E> {
         let begin = align_usize(self.elements.len(), mem::align_of::<T>());
         let len = data.len();
         self.elements.resize(begin, 0);
-        self.elements.extend_from_slice(any_as_u8_slice(&tag));
+        self.elements.extend_from_slice(unsafe { any_as_u8_slice(&tag) });
         mem::forget(tag);
         let elem_begin = align_usize(self.elements.len(), mem::align_of::<E>());
         self.elements.resize(elem_begin, 0);
 
         for elem in data {
-            self.elements.extend_from_slice(any_as_u8_slice(&elem));
+            self.elements.extend_from_slice(unsafe { any_as_u8_slice(&elem) });
             mem::forget(elem);
         }
 
@@ -122,14 +122,14 @@ impl<T, E> TaggedMultiArray<T, E> {
         let begin = align_usize(self.elements.len(), mem::align_of::<T>());
         let len = data.len();
         self.elements.resize(begin, 0);
-        self.elements.extend_from_slice(any_as_u8_slice(&tag));
+        self.elements.extend_from_slice(unsafe { any_as_u8_slice(&tag) });
         mem::forget(tag);
         let elem_begin = align_usize(self.elements.len(), mem::align_of::<E>());
         self.elements.resize(elem_begin, 0);
 
         for elem in data {
             let elem = elem.clone();
-            self.elements.extend_from_slice(any_as_u8_slice(&elem));
+            self.elements.extend_from_slice(unsafe { any_as_u8_slice(&elem) });
             mem::forget(elem);
         }
 


### PR DESCRIPTION
https://github.com/A1Liu/tci/blob/441ff516d974faec922a73daa02c074a2f0ec21c/src/util/general.rs#L293-L295
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.